### PR TITLE
Handle UnsatisfiedLinkError arising from misconfigured MPI

### DIFF
--- a/src/org/volante/abm/serialization/ModelRunner.java
+++ b/src/org/volante/abm/serialization/ModelRunner.java
@@ -68,15 +68,24 @@ public class ModelRunner
 		logger.info("Start CRAFTY CoBRA");
 		
 		String[] realArgs = null;
+
 		try {
 			Class.forName("mpi.MPI");
 			realArgs = MPI.Init(args);
 
+		} catch (NoClassDefFoundError e) {
+			logger.error("No MPI in classpath (this message can be ignored if not running in parallel)!");
+			realArgs = args;
 		} catch (ClassNotFoundException e) {
 			logger.error("No MPI in classpath (this message can be ignored if not running in parallel)!");
 			realArgs = args;
+
+		} catch (UnsatisfiedLinkError e) {
+			logger.error(
+			        "MPI is in classpath but not linked to shared libraries correctly (this message can be ignored if not running in parallel)!");
+			realArgs = args;
 		}
-		//realArgs = args;//Vfix
+
 		CommandLineParser parser = new BasicParser();
 		CommandLine cmd = parser.parse(manageOptions(), realArgs);
 		if (cmd.hasOption('h')) {
@@ -156,10 +165,13 @@ public class ModelRunner
 			Class.forName("mpi.MPI");
 			MPI.Finalize();
 		} catch (ClassNotFoundException e) {
-			logger.error("No MPI in classpath!");
+			logger.info("Error during MPI finilization. No MPI in classpath!");
+//			e.printStackTrace();
+		} catch (NoClassDefFoundError ncde) {
+			logger.info("Error during MPI finilization. No MPI class linked!");
+//			ncde.printStackTrace();
 		} catch (Exception exception) {
-			logger.error("Error during MPI finilization: "
-					+ exception.getMessage());
+			logger.info("Error during MPI finilization: " + exception.getMessage());
 			exception.printStackTrace();
 		}
 	}

--- a/src/org/volante/abm/serialization/WorldLoader.java
+++ b/src/org/volante/abm/serialization/WorldLoader.java
@@ -117,22 +117,30 @@ public class WorldLoader {
 	{
 		RegionSet rs = new RegionSet();
 		for( RegionLoader rl : loaders ) {
-			try {
-				Class.forName("mpi.MPI");
-				if (MPI.COMM_WORLD.Rank() == rl.getUid()) {
-					Region r = loadRegion(rl);
+          Region r = loadRegion(rl);
 
-					logger.info("Run region " + r + " on rank " + MPI.COMM_WORLD.Rank());
+          try {
 
-					rs.addRegion(r);
-				}
-			} catch (ClassNotFoundException exception) {
-				Region r = loadRegion(rl);
+        	  Class.forName("mpi.MPI");
+        	  if (MPI.COMM_WORLD.Rank() == rl.getUid()) {
 
-				logger.info("No MPI. Region " + r + " loaded.");
+        		  logger.info("Run region " + r + " on rank " + MPI.COMM_WORLD.Rank());
 
-				rs.addRegion(r);
-			}
+        	  }
+          } catch (NoClassDefFoundError ncde) {
+        	  logger.error("NoClassDefFoundError: No MPI. Region " + r + " loaded.");
+
+          } catch (UnsatisfiedLinkError ule) {
+        	  logger.error("MPI is in classpath but not linked to shared libraries correctly (this message can be ignored if not running in parallel)!" + " No MPI. Region \" + r + \" loaded.\");");
+
+          } catch (ClassNotFoundException cnfe) {
+        	  logger.error("ClassNotFoundException: No MPI. Region " + r + " loaded.");
+
+          } finally {
+
+        	  rs.addRegion(r);
+
+          }
 		}
 		return rs;
 	}


### PR DESCRIPTION
Updates `ModelRunner.java` and `WorldLoader.java` so they handle cases where the `MPI` class in `mpi.JAR` cannot find required native libraries and was previously throwing an unhandled `UnsatisfiedLinkError` on Linux Mint 20,
despite openmpi being installed.

These changes correspond closely to some changes made in the upstream CRAFTY CoBRA repository in September and October 2020. See links to these commits below. We don't pull in updated copies of these files wholesale as these
updates were made in conjunction with various other changes by the CRAFTY CoBRA maintainers.

https://github.com/CRAFTY-ABM/CRAFTY_CoBRA/commit/640136b57e0d8e52944689fdec91b8d511eeae1c
https://github.com/CRAFTY-ABM/CRAFTY_CoBRA/commit/c8adffc8e2fe6f4994307b3d4a033dba1828ce45

Addresses #1 insofar as it is now possible to run CRAFTY Brazil on Linux, because the  `UnsatisfiedLinkError`s are handled correctly. However the underlying issue of how to configure MPI to work properly with CRAFTY Brazil is not clear. This is something that should be discussed with the CRAFTY CoBRA developers. #1 should therefore remain open.

