### PR TITLE
Remove hard coded paths to the project data directory

### DIFF
--- a/src/org/volante/abm/data/DataDirUtil.java
+++ b/src/org/volante/abm/data/DataDirUtil.java
@@ -1,0 +1,85 @@
+package org.volante.abm.data;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+
+import org.apache.log4j.Logger;
+
+/**
+ * Utility class that gets the path to the CRAFTY Brazil project's {@code data/}
+ * directory.
+ */
+public final class DataDirUtil {
+
+	private final static Logger logger = Logger.getLogger(DataDirUtil.class);
+
+	private DataDirUtil() {
+	} // This utility class cannot be instantiated
+
+	/**
+	 * Get the path to the CRAFTY Brazil project's data directory.
+	 *
+	 * <p>
+	 * Returns {@code $CRAFTY_BRAZIL_HOME/data} if the {@code CRAFTY_BRAZIL_HOME}
+	 * environment variable if it is set. If it is not set defaults to using
+	 * {@code ./data} as the data directory.
+	 * </p>
+	 *
+	 * @return The CRAFTY Brazil project's data directory.
+	 * @throws FileNotFoundException If the {@code CRAFTY_BRAZIL_HOME} environment
+	 *                               variable is set but the directory
+	 *                               {@code $CRAFTY_BRAZIL_HOME/data} directory does
+	 *                               not exist, or if the {@code CRAFTY_BRAZIL_HOME}
+	 *                               directory is <emph>not</emph> set and the
+	 *                               {@code ./data} directory does not exist.
+	 */
+	public static File getDataDir() throws FileNotFoundException {
+		if (readCraftyBrazilHomeEnvVar() != null) {
+			return getDataDirFromEnvironment();
+		} else {
+			logger.warn("CRAFTY_BRAZIL_HOME environment variable not set. Defaulting to current working directory.");
+			return getDefaultDataDir();
+		}
+	}
+
+	/**
+	 * Get the path to the CRAFTY Brazil project data directory assuming the
+	 * {@code CRAFTY_BRAZIL_HOME} environment variable is set.
+	 *
+	 *
+	 * @return The path to {@code $CRAFTY_BRAZIL_HOME/data}.
+	 * @throws FileNotFoundException If no directory exists at
+	 *                               {@code $CRAFTY_BRAZIL_HOME/data}.
+	 */
+	public static File getDataDirFromEnvironment() throws FileNotFoundException {
+		File craftyBrazilHomeDir = new File(readCraftyBrazilHomeEnvVar());
+		File dataDir = new File(craftyBrazilHomeDir, "data");
+		validateDataDir(dataDir);
+		return dataDir;
+	}
+
+	private static String readCraftyBrazilHomeEnvVar() {
+		return System.getenv("CRAFTY_BRAZIL_HOME");
+	}
+
+	/**
+	 * Get the path to the CRAFTY Brazil project data directory assuming the current
+	 * working directory is the CRAFTY Brazil project root.
+	 *
+	 * @return The path to {@code ./data}.
+	 * @throws FileNotFoundException If no directory exists at {@code ./data}.
+	 */
+	public static File getDefaultDataDir() throws FileNotFoundException {
+		File currentDir = new File(System.getProperty("user.dir"));
+		File dataDir = new File(currentDir, "data");
+		validateDataDir(dataDir);
+		return dataDir;
+	}
+
+	private static void validateDataDir(File dir) throws FileNotFoundException {
+		if (!dir.isDirectory()) {
+			throw new FileNotFoundException(dir + " is not a valid data directory");
+		}
+	}
+
+}

--- a/src/org/volante/abm/example/RegionalDemandModel.java
+++ b/src/org/volante/abm/example/RegionalDemandModel.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import org.apache.log4j.Logger;
 import org.simpleframework.xml.Attribute;
 import org.volante.abm.data.Cell;
+import org.volante.abm.data.DataDirUtil;
 import org.volante.abm.data.ModelData;
 import org.volante.abm.data.Region;
 import org.volante.abm.data.Service;
@@ -78,6 +79,7 @@ public class RegionalDemandModel implements DemandModel, PreTickAction, PostTick
 	protected DoubleMap<Service> perCellDemand = null;
 	protected RunInfo runInfo = null;
 	protected ModelData modelData = null;
+	private File dataDir;
 
 	/**
 	 * Name of CSV file that contains per-year demand levels
@@ -117,6 +119,8 @@ public class RegionalDemandModel implements DemandModel, PreTickAction, PostTick
 		if (demandCSV != null) {
 			loadDemandCurves();
 		}
+
+		this.dataDir = DataDirUtil.getDataDir();
 	}
 
 	@Override
@@ -201,7 +205,7 @@ public class RegionalDemandModel implements DemandModel, PreTickAction, PostTick
 		log.info("Loading demand from tick: " + tick);
 		log.info("Waiting for file update");
 		if(tick!=runInfo.getSchedule().getStartTick()){
-			File filex = new File("C:/Users/k1076631/craftyworkspace/CRAFTY_TemplateCoBRA/data/updated2.txt");
+			File filex = new File(this.dataDir, "updated2.txt");
 			try {
 				filex.createNewFile();
 			} catch (IOException e) {
@@ -210,7 +214,7 @@ public class RegionalDemandModel implements DemandModel, PreTickAction, PostTick
 			}
 		}
 		while(true){//VALFIX designed to pause until updated file informs program demand.csv has been updated
-			if(new File("C:/Users/k1076631/craftyworkspace/CRAFTY_TemplateCoBRA/data/updated.txt").isFile()){
+			if(new File(this.dataDir, "updated.txt").isFile()){
 				break;
 			}
 			try {
@@ -222,7 +226,7 @@ public class RegionalDemandModel implements DemandModel, PreTickAction, PostTick
 		}
 		try{
 
-    		File file = new File("C:/Users/k1076631/craftyworkspace/CRAFTY_TemplateCoBRA/data/updated.txt");
+    		File file = new File(this.dataDir, "updated.txt");
     		if(file.exists()){
     		file.delete();}//VALFIX delete updated file ready for next tic
     		

--- a/src/org/volante/abm/update/MaizeChangeFunction.java
+++ b/src/org/volante/abm/update/MaizeChangeFunction.java
@@ -24,6 +24,7 @@ package org.volante.abm.update;
 
 import java.awt.List;
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
@@ -32,6 +33,7 @@ import java.util.ArrayList;
 import org.simpleframework.xml.Attribute;
 import org.volante.abm.data.Capital;
 import org.volante.abm.data.Cell;
+import org.volante.abm.data.DataDirUtil;
 import org.volante.abm.data.ModelData;
 import org.volante.abm.data.Region;
 import org.volante.abm.schedule.RunInfo;
@@ -113,8 +115,8 @@ public class MaizeChangeFunction implements CapitalUpdateFunction {
 			}
 		}*/
 		
-		
-		BufferedReader tr = new BufferedReader(new FileReader("C:\\Users\\k1076631\\craftyworkspace\\CRAFTY_TemplateCoBRA\\data\\csv\\Temperature"+year+".csv"));
+		File csvDir = new File(DataDirUtil.getDataDir(), "csv");
+		BufferedReader tr = new BufferedReader(new FileReader(new File(csvDir, "Temperature"+year+".csv")));
 		String line;
 		
 		 while ((line = tr.readLine()) != null) {
@@ -128,8 +130,8 @@ public class MaizeChangeFunction implements CapitalUpdateFunction {
 		       }
 		 }
 		 tr.close();
-		 
-		 BufferedReader br2 = new BufferedReader(new FileReader("C:\\Users\\k1076631\\craftyworkspace\\CRAFTY_TemplateCoBRA\\data\\csv\\Precipitation"+year+".csv"));
+
+		 BufferedReader br2 = new BufferedReader(new FileReader(new File(csvDir, "Precipitation"+year+".csv")));
 			String line2;
 			 while ((line2 = br2.readLine()) != null) {
 			    	
@@ -198,7 +200,8 @@ public class MaizeChangeFunction implements CapitalUpdateFunction {
 		if (capital == null) {
 			capital = data.capitals.forName(capitalName);
 		}
-		BufferedReader br = new BufferedReader(new FileReader("C:\\Users\\k1076631\\craftyworkspace\\CRAFTY_TemplateCoBRA\\data\\csv\\MaizeSoilQuality.csv"));
+		File csvDir = new File(DataDirUtil.getDataDir(), "csv");
+		BufferedReader br = new BufferedReader(new FileReader(new File(csvDir, "MaizeSoilQuality.csv")));
 		String line=br.readLine();//remove top line of csv
 		
 		 while ((line = br.readLine()) != null) {

--- a/src/org/volante/abm/update/SoyChangeFunction.java
+++ b/src/org/volante/abm/update/SoyChangeFunction.java
@@ -24,6 +24,7 @@ package org.volante.abm.update;
 
 import java.awt.List;
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
@@ -33,6 +34,7 @@ import java.util.Scanner;
 import org.simpleframework.xml.Attribute;
 import org.volante.abm.data.Capital;
 import org.volante.abm.data.Cell;
+import org.volante.abm.data.DataDirUtil;
 import org.volante.abm.data.ModelData;
 import org.volante.abm.data.Region;
 import org.volante.abm.schedule.RunInfo;
@@ -116,8 +118,8 @@ public class SoyChangeFunction implements CapitalUpdateFunction {
 			}
 		}*/
 		
-		
-		BufferedReader tr = new BufferedReader(new FileReader("C:\\Users\\k1076631\\craftyworkspace\\CRAFTY_TemplateCoBRA\\data\\csv\\Update"+year+".csv"));
+		File csvDir = new File(DataDirUtil.getDataDir(), "csv");
+		BufferedReader tr = new BufferedReader(new FileReader(new File(csvDir, "Update"+year+".csv")));
 		String line=tr.readLine();//remove top line of csv
 		
 		 while ((line = tr.readLine()) != null) {
@@ -190,7 +192,8 @@ public class SoyChangeFunction implements CapitalUpdateFunction {
 		if (capital == null) {
 			capital = data.capitals.forName(capitalName);
 		}
-		BufferedReader br = new BufferedReader(new FileReader("C:\\Users\\k1076631\\craftyworkspace\\CRAFTY_TemplateCoBRA\\data\\csv\\Update2000.csv"));
+		File csvDir = new File(DataDirUtil.getDataDir(), "csv");
+		BufferedReader br = new BufferedReader(new FileReader(new File(csvDir, "Update2000.csv")));
 		String line = br.readLine();//remove top line of csv
 		
 		 while ((line = br.readLine()) != null) {


### PR DESCRIPTION
Users should be able to run CRAFTY Brazil on their own file system.

Previously there were several places in the source code that hard-coded the locations of data files. This limited the code's use among people other than the original developers. In this PR we add a `DataDirUtil` class whose methods attempt to read an environment variable called `CRAFTY_BRAZIL_HOME` that specifies where the CRAFTY Brazil repository is on a user's machine. This is then used by CRAFTY Brazil to locate the correct files in the data directory.

If no `CRAFTY_BRAZIL_HOME` variable is set, the `DataDirUtil.getDataDir()` method will attempt to use the user's current working directory as the CRAFTY Brazil home directory.

In this PR we also replace all references to hard-coded file paths with appropriate calls to `DataDirUtil.getDataDir()`.