### PR TITLE
Add log4j configuration to send logs to file and console

### DIFF
--- a/src/log4j.properties
+++ b/src/log4j.properties
@@ -1,0 +1,17 @@
+log4j.rootLogger=INFO, stdout, R
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+
+# Pattern to output the caller's file name and line number.
+log4j.appender.stdout.layout.ConversionPattern=%5p [%t] (%F:%L) - %m%n
+
+log4j.appender.R=org.apache.log4j.RollingFileAppender
+log4j.appender.R.File=output/crafty_brazil.log
+
+log4j.appender.R.MaxFileSize=5000KB
+# Keep 10 backup files
+log4j.appender.R.MaxBackupIndex=5
+
+log4j.appender.R.layout=org.apache.log4j.PatternLayout
+log4j.appender.R.layout.ConversionPattern=%p %t %c - %m%n


### PR DESCRIPTION
Previously no log4j configuration was provided so logs were not visible. This commit adds a `log4j.properties` file that configures the logging system to send logs with level INFO level or above to the console, as well as to the file `output/crafty_brazil.log`.