### PR TITLE
Add an ant build script to simplify model builds

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -84,7 +84,16 @@ ignored.
 The folder ./config/R contains templates to aggregate and visualise simulation output data with R.
 See [crafty wiki](https://www.wiki.ed.ac.uk/display/CRAFTY/Post-Processing) for details.
 
+## Building the project without Eclipse
+
+To help users build the project independently of Eclipse we have provided an `ant` build script, `build.xml`. To rebuild compiled binaries run the following command from the root of this repository.
+
+```bash
+ant clean && ant
+```
+
 ***
 
 If you have any further questions don't hesitate to contact
 Sascha.Holzhauer@ed.ac.uk 
+

--- a/build.xml
+++ b/build.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project basedir="." default="build" name="CRAFTY_Brazil">
+    <property environment="env"/>
+    <property name="debuglevel" value="source,lines,vars"/>
+    <property name="target" value="1.8"/>
+    <property name="source" value="1.7"/>
+    <path id="CRAFTY_Brazil.classpath">
+        <pathelement location="bin"/>
+        <pathelement location="lib/collections-generic-4.01.jar"/>
+        <pathelement location="lib/colt-1.2.0.jar"/>
+        <pathelement location="lib/commons-cli-1.2.jar"/>
+        <pathelement location="lib/commons-math3-3.2.jar"/>
+        <pathelement location="lib/CRAFTY-CoBRA.jar"/>
+        <pathelement location="lib/gt-api-9.0.jar"/>
+        <pathelement location="lib/gt-data-9.0.jar"/>
+        <pathelement location="lib/gt-epsg-wkt-9.0.jar"/>
+        <pathelement location="lib/gt-main-9.0.jar"/>
+        <pathelement location="lib/gt-metadata-9.0.jar"/>
+        <pathelement location="lib/gt-opengis-9.0.jar"/>
+        <pathelement location="lib/gt-referencing-9.0.jar"/>
+        <pathelement location="lib/gt-shapefile-9.0.jar"/>
+        <pathelement location="lib/guava-12.0.1.jar"/>
+        <pathelement location="lib/jai_core.jar"/>
+        <pathelement location="lib/javacsv.jar"/>
+        <pathelement location="lib/javaRasters.jar"/>
+        <pathelement location="lib/jchart2d-3.2.2.jar"/>
+        <pathelement location="lib/jep-2.4.1.jar"/>
+        <pathelement location="lib/jide-oss-2.9.7.jar"/>
+        <pathelement location="lib/JRI.jar"/>
+        <pathelement location="lib/jscience.jar"/>
+        <pathelement location="lib/jts-1.13.jar"/>
+        <pathelement location="lib/jung-algorithms-2.0.1.jar"/>
+        <pathelement location="lib/jung-api-2.0.1.jar"/>
+        <pathelement location="lib/jung-graph-impl-2.0.1.jar"/>
+        <pathelement location="lib/jung-io-2.0.1.jar"/>
+        <pathelement location="lib/LARA_Base.jar"/>
+        <pathelement location="lib/LARA_Toolbox.jar"/>
+        <pathelement location="lib/log4j-1.2.17.jar"/>
+        <pathelement location="lib/ModellingUtilities.jar"/>
+        <pathelement location="lib/monte-cc.jar"/>
+        <pathelement location="lib/MORe.jar"/>
+        <pathelement location="lib/ParMa.jar"/>
+        <pathelement location="lib/repast.simphony.bin_and_src.jar"/>
+        <pathelement location="lib/saf.core.runtime.jar"/>
+        <pathelement location="lib/simple-xml-2.7.1.jar"/>
+        <pathelement location="lib/stax-api-1.0.1.jar"/>
+        <pathelement location="lib/units-0.01.jar"/>
+        <pathelement location="lib/Uranus.jar"/>
+        <pathelement location="lib/vecmath-1.3.1.jar"/>
+        <pathelement location="lib/wstx-asl-3.2.6.jar"/>
+        <pathelement location="lib/xmlgraphics-commons-1.3.1.jar"/>
+        <pathelement location="lib/mpi.jar"/>
+        <pathelement location="lib/jep_ext-1.1.1.jar"/>
+    </path>
+    <target name="init">
+        <mkdir dir="bin"/>
+        <copy includeemptydirs="false" todir="bin">
+            <fileset dir="src">
+                <exclude name="**/*.launch"/>
+                <exclude name="**/*.java"/>
+            </fileset>
+        </copy>
+    </target>
+    <target name="clean">
+        <delete dir="bin"/>
+    </target>
+    <target depends="clean" name="cleanall"/>
+    <target depends="build-subprojects,build-project" name="build"/>
+    <target name="build-subprojects"/>
+    <target depends="init" name="build-project">
+        <echo message="${ant.project.name}: ${ant.file}"/>
+        <javac debug="true" debuglevel="${debuglevel}" destdir="bin" includeantruntime="false" source="${source}" target="${target}">
+            <src path="src"/>
+            <classpath refid="CRAFTY_Brazil.classpath"/>
+        </javac>
+    </target>
+</project>

--- a/src/org/volante/abm/data/Region.java
+++ b/src/org/volante/abm/data/Region.java
@@ -265,12 +265,12 @@ public class Region implements Regions, PreTickAction {
 		return rinfo;
 	}
 
-	MoreNetworkService<SocialAgent, ? extends MoreEdge<SocialAgent>> networkService;
+	MoreNetworkService<SocialAgent, MoreEdge<SocialAgent>> networkService;
 
 	/**
 	 * @return the networkService
 	 */
-	public MoreNetworkService<SocialAgent, ? extends MoreEdge<SocialAgent>> getNetworkService() {
+	public MoreNetworkService<SocialAgent, MoreEdge<SocialAgent>> getNetworkService() {
 		return networkService;
 	}
 
@@ -281,7 +281,7 @@ public class Region implements Regions, PreTickAction {
 	 *        the networkService to set
 	 */
 	public void setNetworkService(
-			MoreNetworkService<SocialAgent, ? extends MoreEdge<SocialAgent>> networkService) {
+			MoreNetworkService<SocialAgent, MoreEdge<SocialAgent>> networkService) {
 		this.networkService = networkService;
 	}
 


### PR DESCRIPTION
When running programs we want to know that we are running the version that corresponds to the version of the source code we have downloaded. To ensure this is the case we should generate executable binaries (i.e. 'build') from source. `ant` scripts help us do this without starting Eclipse. This is especially important when code is being built automatically, such as during a Docker build.

This PR adds an ant script to build the project without using Eclipse.

## Comment on modification to `Region.java`

To get the code to compile under `ant` it was necessary to remove some wildcard type bounds in `Region.java`. The root of this problem is Eclipse's ECJ compiler failing to catch a type error that the OpenJDK implementation of `javac` did catch. See extensive root cause analysis of this problem [here on Stack Overflow](https://stackoverflow.com/questions/65507795). Crucially nothing about the program logic has changed. It may be worth contacting the upstream CRAFTY project about this as I've confirmed the error is in the current version of their code.