### PR TITLE
Remove model displays

### DIFF
--- a/data/xml/Scenario.xml
+++ b/data/xml/Scenario.xml
@@ -8,22 +8,7 @@
 		<output class="org.volante.abm.output.CellTable" addTick="true" addRegion="true" addCellRegion="true"
 				addServices="true" addCapitals="true" addLandUse="true" addAgent="true" doubleFormat="0.000" />				
 	</outputs>
-	<displays  class="org.volante.abm.visualisation.DefaultModelDisplays">
-	    <display class="org.volante.abm.visualisation.AgentTypeDisplay" prefix="" title="AFT Allocation">
-        	<aftColor aft="FR1"><color class="com.moseph.modelutils.serialisation.MColor" r="255" g="231" b="186"/></aftColor>
-        	<aftColor aft="FR2"><color class="com.moseph.modelutils.serialisation.MColor" r="238" g="216" b="174"/></aftColor>
-        	<aftColor aft="FR3"><color class="com.moseph.modelutils.serialisation.MColor" r="205" g="186" b="150"/></aftColor>
-        	<aftColor aft="FR4"><color class="com.moseph.modelutils.serialisation.MColor" r="0" g="100" b="0"/></aftColor>
-        	<aftColor aft="FR5"><color class="com.moseph.modelutils.serialisation.MColor" r="34" g="139" b="34"/></aftColor>
-        	<aftColor aft="FR6"><color class="com.moseph.modelutils.serialisation.MColor" r="0" g="139" b="139"/></aftColor>
-        	<aftColor aft="FR7"><color class="com.moseph.modelutils.serialisation.MColor" r="0" g="0" b="0"/></aftColor>
-        	<aftColor aft="FR8"><color class="com.moseph.modelutils.serialisation.MColor" r="238" g="154" b="0"/></aftColor>
-    	</display>
-		<display class="org.volante.abm.visualisation.CapitalDisplay" initial="Cap1" title="Capitals"/>
-		<display class="org.volante.abm.visualisation.ProductionDisplay" initial="Cereal" title="Production"/>
-		<display class="org.volante.abm.visualisation.AgentTypeDisplay" title="AFT Allocation"/>
-		<display class="org.volante.abm.visualisation.CompetitivenessDisplay" initial="High_Cereals" title="Competitiveness"/>
-		<display class="org.volante.abm.visualisation.SubmodelDisplays" title="Submodels"/>
-	</displays>		
+	<displays class="org.volante.abm.visualisation.NoModelDisplays">
+	</displays>
 	<worldLoaderFile>xml/World_XML.xml</worldLoaderFile>
 </scenario>


### PR DESCRIPTION
Models running in a Docker container generate errors if model displays are specified. Here we remove model display specification from the provided scenario file so that the demo model will run in a Docker container. Note that the inability to run models with graphical displays in Docker is consistent with the CRAFTY documentation's instructions for running on a computing cluster https://www.wiki.ed.ac.uk/display/CRAFTY/Model+Run+Instructions.

Points for discussion:

- It would be nice to keep a demonstration of how to include model displays in this repository. Maybe we should keep `Scenario.xml` as it is and have a second `ScenarioNoDisplay.xml` file for demonstrating how to run the model in Docker?
- An alternative approach might be to have a separate `data` directory used for demonstrating usage with Docker elsewhere, possibly the [Maestro Solo](https://github.com/jamesdamillington/Maestro_Solo) repo.

Let me know what you think @jamesdamillington 